### PR TITLE
Support reproducible builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,10 +14,16 @@ REV = $(shell git rev-parse --short HEAD 2> /dev/null)
 
 SHELL = /bin/bash
 
+BUILD_FLAGS = -trimpath
+ifeq ("${REPRODUCIBLE}","1")
+	BUILD := "REPRODUCIBLE"
+	BUILD_FLAGS := ${BUILD_FLAGS} -buildvcs=false -buildmode=exe
+endif
+
 APP := armory-ums
 GOENV := GO_EXTLINK_ENABLED=0 CGO_ENABLED=0 GOOS=tamago GOARM=7 GOARCH=arm
 TEXT_START := 0x80010000 # ramStart (defined in imx6/imx6ul/memory.go) + 0x10000
-GOFLAGS := -tags linkramsize -trimpath -ldflags "-s -w -T $(TEXT_START) -E _rt0_arm_tamago -R 0x1000 -X 'main.Build=${BUILD}' -X 'main.Revision=${REV}'"
+GOFLAGS := -tags linkramsize ${BUILD_FLAGS} -ldflags "-s -w -T $(TEXT_START) -E _rt0_arm_tamago -R 0x1000 -X 'main.Build=${BUILD}' -X 'main.Revision=${REV}'"
 
 .PHONY: clean
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,15 @@ git clone https://github.com/usbarmory/armory-ums && cd armory-ums
 make CROSS_COMPILE=arm-none-eabi- imx
 ```
 
+Note that the command above embeds build and VCS information that is useful
+for understanding the origin of a binary, but this prevents the same binary
+from being reproducibly built elsewhere. To strip this information so that
+the binary can be reproducibly built elsewhere:
+
+```
+REPRODUCIBLE=1 make imx
+```
+
 Executing
 =========
 


### PR DESCRIPTION
This is required for the Armored Witness project. I've implemented this as optional because it looks like some care went into embedding the full build info, so it must be useful for some other use-cases.
