### PR TITLE
update tamago and fix go.mod parsing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ $(APP): check_tamago
 
 $(APP).dcd: check_tamago
 $(APP).dcd: GOMODCACHE=$(shell ${TAMAGO} env GOMODCACHE)
-$(APP).dcd: TAMAGO_PKG=$(shell grep "github.com/usbarmory/tamago v" go.mod | awk '{print $$1"@"$$2}')
+$(APP).dcd: TAMAGO_PKG=$(shell go list -m -f '{{.Path}}@{{.Version}}' github.com/usbarmory/tamago)
 $(APP).dcd: dcd
 
 $(APP).bin: CROSS_COMPILE=arm-none-eabi-

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,5 @@
 module github.com/usbarmory/armory-ums
 
-go 1.24.3
+go 1.25.6
 
-require (
-	github.com/usbarmory/tamago v0.0.0-20250527211737-92513e7e3efd
-)
+require github.com/usbarmory/tamago v1.25.6

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/usbarmory/tamago v0.0.0-20250527211737-92513e7e3efd h1:TAbdlUdB2NfImyrCYgE5iNaW4OzrlEe64/I6bzoaIXM=
-github.com/usbarmory/tamago v0.0.0-20250527211737-92513e7e3efd/go.mod h1:BtIwki3LlSlQJ/sW1wL2unqgYndZsSDioeyI3bVtZO8=
+github.com/usbarmory/tamago v1.25.6 h1:qt1CkH/cI9EMv+7wRMRT2yqQPIWRjokBBLnKehg1NaQ=
+github.com/usbarmory/tamago v1.25.6/go.mod h1:jZIgiYSQmVoZyxvzHmzamNi36eZv790/5SO6lhds+W4=


### PR DESCRIPTION
Tried on a Mk II, it boots with SDP and a disk is recognized, but then

```
sudo dd if=example.imx of=/dev/rdisk6 bs=512 seek=2
dd: /dev/rdisk6: Device not configured
```

and the disk disappear.

Not sure if related to the update. Before the update it did not build with the latest Tamago compiler.